### PR TITLE
adds gulp, babel, browserify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+public/bundle.js
+public/bundle.js.map

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # TheEmpire
 
-### To start the server and have it automatically restart on code changes:
+### Build scripts, start server, and automatically build and restart on changes:
 ``` sh
   $ npm run watch
 ```
 
-### To beautify all files:
+### Build scripts:
+``` sh
+  $ npm run build
+```
+
+### Beautify all files:
 ``` sh
   $ npm run beautify
 ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,69 @@
+const gulp = require('gulp');
+const sourcemaps = require('gulp-sourcemaps');
+const source = require('vinyl-source-stream');
+const buffer = require('vinyl-buffer');
+const browserify = require('browserify');
+const babel = require('babelify');
+const nodemon = require('gulp-nodemon');
+const prettify = require('gulp-jsbeautifier');
+
+// Gulp Tasks
+gulp.task('beautify', beautify);
+gulp.task('build', build);
+gulp.task('watch', ['build'], watch);
+
+gulp.task('default', ['watch']);
+
+const globsToBuild = [
+  'public/scripts/*.js'
+];
+
+const globsToBeautify = [
+  '*.js',
+  'public/**/*.js',
+  'public/**/*.html',
+  'public/**/*.css',
+  '!public/bundle.js*' // don't beautify our bundled scripts
+];
+
+// Task implementations
+function beautify() {
+  return gulp.src(globsToBeautify, { base: './' })
+    .pipe(prettify())
+    .pipe(gulp.dest('./'));
+}
+
+function build() {
+  return browserify({
+      entries: ['public/scripts/main.js'],
+      debug: true,
+      extensions: ['js']
+    })
+    .transform(babel, {
+      presets: ['es2015']
+    })
+    .bundle()
+    .on('error', err => {
+      console.error(err);
+    })
+    .pipe(source('bundle.js'))
+    .pipe(buffer())
+    .pipe(sourcemaps.init({
+      loadMaps: true
+    }))
+    .pipe(sourcemaps.write('./'))
+    .pipe(gulp.dest('public'));
+}
+
+function watch() {
+  // restart Node.js server on backend changes
+  nodemon({
+    script: 'server.js',
+    watch: ['*.js'],
+    ext: 'js',
+    ignore: ['gulpfile.js', 'public/'],
+  });
+
+  // re-transpile and rebundle scripts on frontend changes
+  gulp.watch(globsToBuild, ['build']);
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "accepts": {
       "version": "1.3.3",
-      "from": "accepts@1.3.3",
+      "from": "accepts@>=1.3.3 <1.4.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz"
     },
     "after": {
@@ -68,9 +68,9 @@
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
     },
     "content-disposition": {
-      "version": "0.5.1",
-      "from": "content-disposition@0.5.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
+      "version": "0.5.2",
+      "from": "content-disposition@0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
     },
     "content-type": {
       "version": "1.0.2",
@@ -88,9 +88,9 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
     },
     "debug": {
-      "version": "2.3.3",
-      "from": "debug@2.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
+      "version": "2.2.0",
+      "from": "debug@>=2.2.0 <2.3.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
     },
     "depd": {
       "version": "1.1.0",
@@ -115,7 +115,19 @@
     "engine.io": {
       "version": "1.8.2",
       "from": "engine.io@1.8.2",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.2.tgz"
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.2.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
+        },
+        "ms": {
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+        }
+      }
     },
     "engine.io-client": {
       "version": "1.8.2",
@@ -126,6 +138,16 @@
           "version": "1.2.1",
           "from": "component-emitter@1.2.1",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
+        },
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
+        },
+        "ms": {
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
         }
       }
     },
@@ -145,38 +167,14 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
     },
     "express": {
-      "version": "4.14.0",
-      "from": "express@latest",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "ms": {
-          "version": "0.7.1",
-          "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-        }
-      }
+      "version": "4.14.1",
+      "from": "express@>=4.14.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.14.1.tgz"
     },
     "finalhandler": {
-      "version": "0.5.0",
-      "from": "finalhandler@0.5.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@~2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "ms": {
-          "version": "0.7.1",
-          "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-        }
-      }
+      "version": "0.5.1",
+      "from": "finalhandler@0.5.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.1.tgz"
     },
     "forwarded": {
       "version": "0.1.0",
@@ -200,7 +198,7 @@
     },
     "http-errors": {
       "version": "1.5.1",
-      "from": "http-errors@>=1.5.0 <1.6.0",
+      "from": "http-errors@>=1.5.1 <1.6.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz"
     },
     "indexof": {
@@ -259,9 +257,9 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz"
     },
     "ms": {
-      "version": "0.7.2",
-      "from": "ms@0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+      "version": "0.7.1",
+      "from": "ms@0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
     },
     "negotiator": {
       "version": "0.6.1",
@@ -315,7 +313,7 @@
     },
     "proxy-addr": {
       "version": "1.1.3",
-      "from": "proxy-addr@>=1.1.2 <1.2.0",
+      "from": "proxy-addr@>=1.1.3 <1.2.0",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.3.tgz"
     },
     "qs": {
@@ -329,45 +327,21 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
     },
     "send": {
-      "version": "0.14.1",
-      "from": "send@0.14.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+      "version": "0.14.2",
+      "from": "send@0.14.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.14.2.tgz",
       "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@~2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
         "ms": {
-          "version": "0.7.1",
-          "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
         }
       }
     },
     "serve-static": {
       "version": "1.11.2",
-      "from": "serve-static@>=1.11.1 <1.12.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.2.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@~2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.7.1",
-              "from": "ms@0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-            }
-          }
-        },
-        "send": {
-          "version": "0.14.2",
-          "from": "send@0.14.2",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.14.2.tgz"
-        }
-      }
+      "from": "serve-static@>=1.11.2 <1.12.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.2.tgz"
     },
     "setprototypeof": {
       "version": "1.0.2",
@@ -376,13 +350,37 @@
     },
     "socket.io": {
       "version": "1.7.2",
-      "from": "socket.io@latest",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.2.tgz"
+      "from": "socket.io@>=1.7.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.2.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
+        },
+        "ms": {
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+        }
+      }
     },
     "socket.io-adapter": {
       "version": "0.5.0",
       "from": "socket.io-adapter@0.5.0",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
+        },
+        "ms": {
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+        }
+      }
     },
     "socket.io-client": {
       "version": "1.7.2",
@@ -393,29 +391,27 @@
           "version": "1.2.1",
           "from": "component-emitter@1.2.1",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
+        },
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
+        },
+        "ms": {
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
         }
       }
     },
     "socket.io-parser": {
       "version": "2.3.1",
       "from": "socket.io-parser@2.3.1",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "ms": {
-          "version": "0.7.1",
-          "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz"
     },
     "statuses": {
       "version": "1.3.1",
-      "from": "statuses@>=1.3.0 <1.4.0",
+      "from": "statuses@>=1.3.1 <1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
     },
     "to-array": {
@@ -425,7 +421,7 @@
     },
     "type-is": {
       "version": "1.6.14",
-      "from": "type-is@>=1.6.13 <1.7.0",
+      "from": "type-is@>=1.6.14 <1.7.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz"
     },
     "ultron": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "game1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ZakMiller/TheEmpire.git"
+  },
   "version": "1.0.0",
   "description": "",
   "main": "server.js",
   "scripts": {
-    "watch": "nodemon server.js --ignore public",
-    "beautify": "glob-run js-beautify -r *.js && glob-run js-beautify -r public/scripts/*.js && glob-run js-beautify -r public/styles/*.css && glob-run js-beautify -r public/*.html",
+    "watch": "gulp watch",
+    "build": "gulp build",
+    "beautify": "gulp beautify",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
@@ -15,8 +20,14 @@
     "socket.io": "^1.7.2"
   },
   "devDependencies": {
-    "glob-run": "^0.1.6",
-    "js-beautify": "^1.6.8",
-    "nodemon": "^1.11.0"
+    "babel-preset-es2015": "^6.22.0",
+    "babelify": "^7.3.0",
+    "browserify": "^14.0.0",
+    "gulp": "^3.9.1",
+    "gulp-jsbeautifier": "^2.0.4",
+    "gulp-nodemon": "^2.2.1",
+    "gulp-sourcemaps": "^2.4.0",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -2,12 +2,12 @@
 
 <head>
   <link rel="stylesheet" type="text/css" href="styles/interface.css">
-  <script src="/socket.io/socket.io.js"></script>
-  <script src="scripts/main.js"></script>
+  <script defer src="/socket.io/socket.io.js"></script>
+  <script defer src="bundle.js"></script>
 </head>
 
 <body>
-  <input id="input" autocomplete="off" /><button onClick="sendMessage()">SEND</button>
+  <input id="input" autocomplete="off" /><button>SEND</button>
   <ul id='messages'></ul>
 </body>
 

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -5,6 +5,8 @@ var username = prompt('enter your name');
 
 socket.on('incomingMessage', appendIncomingMessage);
 
+document.querySelector('button').addEventListener('click', sendMessage);
+
 //return true or false if message meets criteria
 function isMessageValid() {
 


### PR DESCRIPTION
`gulp` is a build tool that lets you automate certain repetitive workflows. In this case, it helps automate the standard workflow of
```
   make changes -> save files -> babelify -> browserify -> restart server
```
It could probably use some tweaking, like only restarting the server if our backend files have changed & only building when our frontend files have changed. I can work on that later.
**edit:** I've got it restarting server on backend changes and rebuilding frontend scripts when they change now

For now though, you just run `npm run watch` (or `gulp` if you install gulp globally) and it'll watch for any code change. When it sees a change, it'll transpile our code from ES6 -> ES5, bundle our frontend code and all it's `require`'d dependencies into one file (`public/bundle.js`), which is the only file we'll need to include in our html.

I can go over it with y'all some point this week. But I think this should make our lives a lot easier. Shouldn't be horrible to add in extra stuff if necessary (though I couldn't figure out how to automatically beautify without infinite looping...)