### PR TITLE
fix gulp.watch crash on frontend syntax error

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -2,7 +2,6 @@
   "indent_size": 2,
   "indent_char": " ",
   "indent_with_tabs": false,
-  "eol": "\n",
   "end_with_newline": true,
   "indent_level": 0,
   "preserve_newlines": true,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,4 @@
+const os = require('os');
 const gulp = require('gulp');
 const sourcemaps = require('gulp-sourcemaps');
 const source = require('vinyl-source-stream');
@@ -28,15 +29,17 @@ const globsToBeautify = [
 
 // Task implementations
 function beautify() {
-  return gulp.src(globsToBeautify, {
+  gulp.src(globsToBeautify, {
       base: './'
     })
-    .pipe(prettify())
+    .pipe(prettify({
+      eol: os.EOL, // \r\n on Windows, \n on POSIX
+    }))
     .pipe(gulp.dest('./'));
 }
 
 function build() {
-  return browserify({
+  browserify({
       entries: ['public/scripts/main.js'],
       debug: true,
       extensions: ['js']
@@ -46,7 +49,8 @@ function build() {
     })
     .bundle()
     .on('error', err => {
-      console.error(err);
+      console.error(err.stack);
+      console.error('\nScroll up and fix your errors!');
     })
     .pipe(source('bundle.js'))
     .pipe(buffer())


### PR DESCRIPTION
Please merge this ASAP. I'd do it myself but it's not proper.

Basically, this fixes a bug where the watcher will crash and stop watching even though it looks like it is.

I also made the error logging a bit nicer and more helpful